### PR TITLE
GitHub actions and cross-platform generate_resources.sh

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,7 +34,11 @@ jobs:
           cd xcbeautify
           git checkout 2.0.1
           swift build -c release
-          sudo cp .build/release/xcbeautify /usr/bin/xcbeautify
+          if [[ ${{ runner.os }} == "Linux" ]]; then
+            sudo cp .build/release/xcbeautify /usr/bin/xcbeautify
+          else
+            sudo cp .build/release/xcbeautify /usr/local/bin/xcbeautify
+          fi
 
       - name: Build Project
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          set -o pipefail && xcodebuild [flags] | xcbeautify --renderer github-actions
+          set -o pipefail && swift test | xcbeautify --renderer github-actions
 
       - name: Run Benchmarks
         run: swift package benchmark

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: swift-actions/setup-swift@v2
         with:
-          swift-version: "5.1.0"
+          swift-version: "5.9.0"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           swift-version: "5.9.0"
 
+      - name: Setup Swift (macOS only)
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_15.0.1.app"
+
       - name: Install libjemalloc-dev (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,6 +31,11 @@ jobs:
           sudo apt update
           sudo apt install libjemalloc-dev -y
 
+      - name: Install libjemalloc-dev (macOS only)
+        if: matrix.os == 'macos-13'
+        run: |
+          brew install jemalloc
+
       - name: Install Dependencies
         run: |
           git clone https://github.com/cpisciotta/xcbeautify

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.1.0"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,7 @@ name: Build and Test Workflow
 
 on:
   push:
-    branches:
-      - "master"
-      - "github-actions"
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -24,11 +24,6 @@ jobs:
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: "5.9.0"
-
-      - name: Setup Swift (macOS only)
-        if: matrix.os == 'macos-latest'
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_15.0.app"
 
       - name: Install libjemalloc-dev (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           swift-version: "5.9.0"
 
+      - name: Install libjemalloc-dev (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update
+          sudo apt install libjemalloc-dev -y
+
       - name: Install Dependencies
         run: |
           git clone https://github.com/cpisciotta/xcbeautify

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,11 +2,11 @@ name: Build and Test Workflow
 
 on:
   push:
-    branches: 
+    branches:
       - "master"
       - "github-actions"
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   build-and-test:
@@ -15,25 +15,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install Dependencies
-      run: |
-        git clone https://github.com/cpisciotta/xcbeautify
-        cd xcbeautify
-        git checkout 2.0.1
-        swift build -c release
-        sudo cp .build/release/xcbeautify /usr/bin/xcbeautify
+      - name: Install Dependencies
+        run: |
+          git clone https://github.com/cpisciotta/xcbeautify
+          cd xcbeautify
+          git checkout 2.0.1
+          swift build -c release
+          cp .build/release/xcbeautify /usr/bin/xcbeautify
 
-    - name: Build Project
-      run: |
-        ./generate_resources.sh
-        swift build -v
+      - name: Build Project
+        run: |
+          ./generate_resources.sh
+          swift build -v
 
-    - name: Run Tests (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: |
-        set -o pipefail && xcodebuild [flags] | xcbeautify --renderer github-actions
+      - name: Run Tests
+        run: |
+          set -o pipefail && xcodebuild [flags] | xcbeautify --renderer github-actions
 
-    - name: Run Benchmarks
-      run: swift package benchmark
+      - name: Run Benchmarks
+        run: swift package benchmark

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,39 @@
+name: Build and Test Workflow
+
+on:
+  push:
+    branches: 
+      - "master"
+      - "github-actions"
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: |
+        git clone https://github.com/cpisciotta/xcbeautify
+        cd xcbeautify
+        git checkout 2.0.1
+        swift build -c release
+        sudo cp .build/release/xcbeautify /usr/bin/xcbeautify
+
+    - name: Build Project
+      run: |
+        ./generate_resources.sh
+        swift build -v
+
+    - name: Run Tests (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: |
+        set -o pipefail && xcodebuild [flags] | xcbeautify --renderer github-actions
+
+    - name: Run Benchmarks
+      run: swift package benchmark

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,7 +26,7 @@ jobs:
           cd xcbeautify
           git checkout 2.0.1
           swift build -c release
-          cp .build/release/xcbeautify /usr/bin/xcbeautify
+          sudo cp .build/release/xcbeautify /usr/bin/xcbeautify
 
       - name: Build Project
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "true"
-      - uses: swift-actions/setup-swift@v2
+
+      - name: Setup Swift (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: swift-actions/setup-swift@v2
         with:
           swift-version: "5.9.0"
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Swift (macOS only)
         if: matrix.os == 'macos-latest'
         run: |
-          sudo xcode-select -s "/Applications/Xcode_15.0.1.app"
+          sudo xcode-select -s "/Applications/Xcode_15.0.app"
 
       - name: Install libjemalloc-dev (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,6 +16,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: "true"
       - uses: swift-actions/setup-swift@v2
         with:
           swift-version: "5.9.0"

--- a/generate_resources.sh
+++ b/generate_resources.sh
@@ -5,12 +5,12 @@ STDLIB_PATH="pkl/stdlib"
 OUTPUT_FILE="Sources/pkl-lsp/Resources.swift"
 
 # Start the Resources struct and hashMap
-echo "// This file is auto-generated. Do not edit directly.\n" > "$OUTPUT_FILE"
+echo "// This file is auto-generated. Do not edit directly." > "$OUTPUT_FILE"
 echo "public enum Resources {" >> "$OUTPUT_FILE"
 echo "    public static let stdlib: [String: String] = [" >> "$OUTPUT_FILE"
 
 # Process each .pkl file
-find "$STDLIB_PATH" -name "*.pkl" | while IFS= read -r file; do
+while IFS= read -r file; do
     filename=$(basename -- "$file")
     echo "Processing $filename..."
     echo "        \"${filename}\": \"\"\"" >> "$OUTPUT_FILE"
@@ -21,22 +21,14 @@ find "$STDLIB_PATH" -name "*.pkl" | while IFS= read -r file; do
         echo "$escapedLine" >> "$OUTPUT_FILE"
     done < "$file"
     echo "\"\"\"," >> "$OUTPUT_FILE"
-done
+done < <(find "$STDLIB_PATH" -name "*.pkl")
 
-# Finish the hashMap and Resources struct
-# Use `head` and `tail` to remove the last comma from the hashMap
-echo "    ]" >> "$OUTPUT_FILE"
-echo "}" >> "$OUTPUT_FILE"
+# Use sed to remove the last comma. This approach is compatible across both GNU and BSD sed.
+# -i '' -e: For BSD sed compatibility, specifying an empty extension for in-place editing without backup.
+# $!N; $!ba; : For GNU sed, to accumulate the whole file into pattern space.
+# s/,\n    \]/\n    ]/: To remove the last comma before the closing square bracket.
+sed -i '' -e '$!N; $!ba; s/,\n    \]/\n    ]/' "$OUTPUT_FILE"
 
-# Correctly format the Swift dictionary to remove the last comma
-# Temporary file for intermediate output
-TMP_FILE="${OUTPUT_FILE}.tmp"
+echo "]}" >> "$OUTPUT_FILE"
 
-# Leave the last two lines (closing brackets) untouched, remove the last comma from the rest
-head -n -2 "$OUTPUT_FILE" | sed '$ s/,$//' > "$TMP_FILE"
-tail -n 2 "$OUTPUT_FILE" >> "$TMP_FILE"
-
-# Replace original file with corrected one
-mv "$TMP_FILE" "$OUTPUT_FILE"
 echo "Done!"
-

--- a/generate_resources.sh
+++ b/generate_resources.sh
@@ -1,32 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Define the input directory and output Swift file
 STDLIB_PATH="pkl/stdlib"
 OUTPUT_FILE="Sources/pkl-lsp/Resources.swift"
 
 # Start the Resources struct and hashMap
-echo "// This file is auto-generated. Do not edit directly.\n" > $OUTPUT_FILE
-echo "public enum Resources {" >> $OUTPUT_FILE
-echo "    public static let stdlib: [String: String] = [" >> $OUTPUT_FILE
+echo "// This file is auto-generated. Do not edit directly.\n" > "$OUTPUT_FILE"
+echo "public enum Resources {" >> "$OUTPUT_FILE"
+echo "    public static let stdlib: [String: String] = [" >> "$OUTPUT_FILE"
 
 # Process each .pkl file
-find "$STDLIB_PATH" -name "*.pkl" | while read file; do
+find "$STDLIB_PATH" -name "*.pkl" | while IFS= read -r file; do
     filename=$(basename -- "$file")
     echo "Processing $filename..."
-    echo "        \"${filename}\": \"\"\"" >> $OUTPUT_FILE
+    echo "        \"${filename}\": \"\"\"" >> "$OUTPUT_FILE"
 
     # Append file contents, escaping backslashes and double quotes
     while IFS= read -r line; do
         escapedLine=$(echo "$line" | sed 's/\\/\\\\/g; s/\"/\\"/g')
-        echo "$escapedLine" >> $OUTPUT_FILE
+        echo "$escapedLine" >> "$OUTPUT_FILE"
     done < "$file"
-    echo "\"\"\"," >> $OUTPUT_FILE
+    echo "\"\"\"," >> "$OUTPUT_FILE"
 done
 
 # Finish the hashMap and Resources struct
 # Use `head` and `tail` to remove the last comma from the hashMap
-echo "    ]" >> $OUTPUT_FILE
-echo "}" >> $OUTPUT_FILE
+echo "    ]" >> "$OUTPUT_FILE"
+echo "}" >> "$OUTPUT_FILE"
 
 # Correctly format the Swift dictionary to remove the last comma
 # Temporary file for intermediate output
@@ -39,3 +39,4 @@ tail -n 2 "$OUTPUT_FILE" >> "$TMP_FILE"
 # Replace original file with corrected one
 mv "$TMP_FILE" "$OUTPUT_FILE"
 echo "Done!"
+


### PR DESCRIPTION
generate_resources.sh is still not perfect (bringing `sed: can't find label for jump to 'a'`) but it seems to work now both on macOS and Linux